### PR TITLE
Add tag-and-release workflow file.

### DIFF
--- a/.github/workflows/tag-and-release-pipeline.yml
+++ b/.github/workflows/tag-and-release-pipeline.yml
@@ -1,0 +1,60 @@
+name: Release Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag-release:
+    name: Tag & Release
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate GitHub App Token
+        id: generate_github_app_token
+        uses: tibdex/github-app-token@v1.8.0
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_github_app_token.outputs.token }}
+          persist-credentials: true
+      
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '3.1.x'
+        env: 
+          DOTNET_INSTALL_DIR: ${{ runner.workspace }}/dotnet
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0
+        with:
+          versionSpec: '5.x'
+        
+      - name: Get GitVersion
+        id: get_gitversion
+        uses: gittools/actions/gitversion/execute@v0
+        with:
+          useConfigFile: true
+          configFilePath: GitVersion.yml
+      
+      - name: Tag and Release
+        env: 
+          GITHUB_TOKEN: ${{ steps.generate_github_app_token.outputs.token }}
+        run: |
+          git config user.name "GitHub Actions [bot]"
+          git config user.email "actions@github.com"
+          git status # This is just to check if the git config worked
+          git pull origin main # In case any changes were made since checkout
+          git tag ${{ steps.get_gitversion.outputs.majorMinorPatch }} -m "Release ${{ steps.get_gitversion.outputs.majorMinorPatch }}"
+          git push --tags
+
+          # Create a release
+          gh release create ${{ steps.get_gitversion.outputs.majorMinorPatch }} \
+            --title "${{ steps.get_gitversion.outputs.majorMinorPatch }}" \
+            --generate-notes

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+mode: Mainline
+ignore:
+  sha: []
+  commits-before: '2023-05-10T12:00:00'
+branches: {}

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Contains the ML training pipeline used for the main project of course CS4295: Re
 ## Dependencies
 All required packages can be found in dep/requirements.txt. To install the required packages, run the following command:
 
-`$ pip install -r dep/requirements.txt`
+```bash
+pip install -r dep/requirements.txt
+```
 
 ## Dataset
-Project was created using the dataset provided by course instructors on SURFdrive:
-https://surfdrive.surf.nl/files/index.php/s/207BTysNQFuVZPE?path=%2Fmaterial
+Project was created using the dataset provided by course instructors on [SURFdrive](https://surfdrive.surf.nl/files/index.php/s/207BTysNQFuVZPE?path=%2Fmaterial)
 
-To use this repository, please download the archive at the link above, unzip the archive and place the restaurant-sentiment/ folder in the main model-training folder.
+To use this repository, please download the archive at the link above, unzip the archive and place the `restaurant-sentiment/` folder in the main `model-training` folder.
 
 ## Usage
 To manually generate a new ML model, execute `main.py`. 
@@ -20,4 +21,4 @@ Any preprocessing steps can be found in `preprocessing.py`. These are executed a
 
 
 ### Storing the trained model
-The trained model is stored in the res/ folder.
+The trained model is stored in the `res/` folder.


### PR DESCRIPTION
Add workflow for automatically tagging and making a github release when pushing to main branch. 
Using Mainline branching strategy for automatic detection of commits pushed to the main branch.
Exlucding commits before 10th of May in order to limit starting date of reasable components (since initial commits until then were for development without mainline strategy) 